### PR TITLE
Review setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ __pycache__/
 /_meta.py
 /build/
 /dist/
-/$distname/__init__.py

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,10 @@ doc-pdf: meta
 
 clean:
 	rm -rf build
-	rm -rf __pycache__ $distname/__pycache__
+	rm -rf __pycache__
 
 distclean: clean
 	rm -f MANIFEST _meta.py
-	rm -f $distname/__init__.py
 	rm -rf dist
 	rm -rf tests/.pytest_cache
 	$(MAKE) -C doc distclean

--- a/README.rst
+++ b/README.rst
@@ -23,13 +23,13 @@ Required library packages:
 
 Optional library packages:
 
-+ `setuptools_scm`_
++ `git-props`_
 
-  The version number is managed using this package.  All source
-  distributions add a static text file with the version number and
-  fall back using that if `setuptools_scm` is not available.  So this
-  package is only needed to build out of the plain development source
-  tree as cloned from GitHub.
+  This package is used to extract some metadata such as the version
+  number out of git, the version control system.  All releases embed
+  that metadata in the distribution.  So this package is only needed
+  to build out of the plain development source tree as cloned from
+  GitHub, but not to build a release distribution.
 
 + `pytest`_ >= 3.0
 
@@ -56,7 +56,7 @@ permissions and limitations under the License.
 
 
 .. _setuptools: https://github.com/pypa/setuptools/
-.. _setuptools_scm: https://github.com/pypa/setuptools_scm/
+.. _git-props: https://github.com/RKrahl/git-props
 .. _pytest: https://pytest.org/
 .. _distutils-pytest: https://github.com/RKrahl/distutils-pytest
 .. _Apache License: https://www.apache.org/licenses/LICENSE-2.0

--- a/init.py
+++ b/init.py
@@ -17,8 +17,6 @@ if tags:
 
 
 distname_files = (
-    Path(".gitignore"),
-    Path("Makefile"),
     Path("doc/Makefile"),
     Path("doc/src/conf.py"),
     Path("doc/src/index.rst"),
@@ -35,10 +33,15 @@ for path in distname_files:
         f.write(s.safe_substitute(distname=args.distname))
     subprocess.check_call(["git", "add", str(path)])
 
+Path("src/%s" % args.distname).mkdir()
 subprocess.check_call(["git", "mv",
                        "python-skel.spec", "python-%s.spec" % args.distname])
+subprocess.check_call(["git", "mv",
+                       "src/distname/__init__.py",
+                       "src/%s/__init__.py" % args.distname])
 subprocess.check_call(["git", "rm", "init.py"])
 subprocess.check_call(["git", "commit", "-m", "Set the name of the package"])
+Path("src/distname").rmdir()
 
 print("""Name of the package set.
 

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,7 @@ try:
     version = setuptools_scm.get_version()
 except (ImportError, LookupError):
     try:
-        import _meta
-        version = _meta.__version__
+        from _meta import version
     except ImportError:
         log.warn("warning: cannot determine version number")
         version = "UNKNOWN"
@@ -40,7 +39,7 @@ class meta(setuptools.Command):
 __version__ = "%(version)s"
 '''
     meta_template = '''
-__version__ = "%(version)s"
+version = "%(version)s"
 '''
 
     def initialize_options(self):

--- a/setup.py
+++ b/setup.py
@@ -34,40 +34,22 @@ class meta(setuptools.Command):
 
     description = "generate meta files"
     user_options = []
-    init_template = '''"""%(doc)s"""
-
-__version__ = "%(version)s"
-'''
     meta_template = '''
 version = "%(version)s"
 '''
 
     def initialize_options(self):
-        self.package_dir = None
+        pass
 
     def finalize_options(self):
-        self.package_dir = {}
-        if self.distribution.package_dir:
-            for name, path in self.distribution.package_dir.items():
-                self.package_dir[name] = convert_path(path)
+        pass
 
     def run(self):
         version = self.distribution.get_version()
         log.info("version: %s", version)
         values = {
             'version': version,
-            'doc': docstring,
         }
-        try:
-            pkgname = self.distribution.packages[0]
-        except IndexError:
-            log.warn("warning: no package defined")
-        else:
-            pkgdir = Path(self.package_dir.get(pkgname, pkgname))
-            if not pkgdir.is_dir():
-                pkgdir.mkdir()
-            with (pkgdir / "__init__.py").open("wt") as f:
-                print(self.init_template % values, file=f)
         with Path("_meta.py").open("wt") as f:
             print(self.meta_template % values, file=f)
 
@@ -135,6 +117,7 @@ setup(
         #Changes="https://$distname.readthedocs.io/en/latest/changelog.html",
     ),
     packages = ["$distname"],
+    package_dir = {"": "src"},
     python_requires = ">=3.6",
     install_requires = [],
     cmdclass = dict(cmdclass, build_py=build_py, sdist=sdist, meta=meta),

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,6 @@ setup(
     packages = ["$distname"],
     package_dir = {"": "src"},
     python_requires = ">=3.6",
-    install_requires = [],
+    install_requires = ["setuptools"],
     cmdclass = dict(cmdclass, build_py=build_py, sdist=sdist, meta=meta),
 )

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,9 @@ class build_py(setuptools.command.build_py.build_py):
     def run(self):
         self.run_command('meta')
         super().run()
+        package = self.distribution.packages[0].split('.')
+        outfile = self.get_module_outfile(self.build_lib, package, "_meta")
+        self.copy_file("_meta.py", outfile, preserve_mode=0)
 
 
 with Path("README.rst").open("rt", encoding="utf8") as f:

--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,14 @@ except (ImportError, AttributeError):
     cmdclass = dict()
 try:
     import gitprops
+    release = str(gitprops.get_last_release())
     version = str(gitprops.get_version())
 except (ImportError, LookupError):
     try:
-        from _meta import version
+        from _meta import release, version
     except ImportError:
         log.warn("warning: cannot determine version number")
-        version = "UNKNOWN"
+        release = version = "UNKNOWN"
 
 docstring = __doc__
 
@@ -35,6 +36,7 @@ class meta(setuptools.Command):
     description = "generate meta files"
     user_options = []
     meta_template = '''
+release = "%(release)s"
 version = "%(version)s"
 '''
 
@@ -48,6 +50,7 @@ version = "%(version)s"
         version = self.distribution.get_version()
         log.info("version: %s", version)
         values = {
+            'release': release,
             'version': version,
         }
         with Path("_meta.py").open("wt") as f:
@@ -113,7 +116,7 @@ setup(
     project_urls = dict(
         #Documentation="https://$distname.readthedocs.io/",
         Source="https://github.com/RKrahl/$distname",
-        Download="https://github.com/RKrahl/$distname/releases/latest",
+        Download=("https://github.com/RKrahl/$distname/releases/%s/" % release),
         #Changes="https://$distname.readthedocs.io/en/latest/changelog.html",
     ),
     packages = ["$distname"],

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ try:
 except (ImportError, AttributeError):
     cmdclass = dict()
 try:
-    import setuptools_scm
-    version = setuptools_scm.get_version()
+    import gitprops
+    version = str(gitprops.get_version())
 except (ImportError, LookupError):
     try:
         from _meta import version

--- a/src/distname/__init__.py
+++ b/src/distname/__init__.py
@@ -1,0 +1,1 @@
+from ._meta import version as __version__


### PR DESCRIPTION
Various changes in the setup scripts:

- rename the `__version__` attribute in `_meta.py` to `version`,
- include `_meta.py` as a module to the installed package,
- do not auto generate `__init__.py`, rather add a static `__init__.py` that imports the version from `_meta`,
- drop [setuptools_scm](https://github.com/pypa/setuptools_scm/) in favour of [git-props](https://github.com/RKrahl/git-props),
- also store the last release version in `_meta` and use it to explicitly point to the last release rather than to "latest" in the download url,
- add setuptools to install requires.
